### PR TITLE
Mark hardware registers as volatile

### DIFF
--- a/source/hw.c
+++ b/source/hw.c
@@ -2,4 +2,4 @@
 #include "hw.h"
 
 
-u8* const HW_REGS = (u8*)0x02000000;
+volatile u8* const HW_REGS = (u8*)0x02000000;

--- a/source/hw.h
+++ b/source/hw.h
@@ -5,7 +5,7 @@
 #include "types.h"
 
 
-extern u8* const HW_REGS;
+extern volatile u8* const HW_REGS;
 
 /***** Hardware Register Mnemonics *****/
 #define	CCR		0x00	// Communication Control Register	(0x0200 0000)


### PR DESCRIPTION
GCC may do many unexpected things since the memory mapped hardware registers are not marked volatile. Mark them as such.