### PR TITLE
Mark all other direct MMIO as volatile

### DIFF
--- a/source/audio.c
+++ b/source/audio.c
@@ -2,10 +2,10 @@
 #include "audio.h"
 
 
-u8* const WAVEDATA1 =		(u8*)0x01000000;
-u8* const WAVEDATA2 =		(u8*)0x01000080;
-u8* const WAVEDATA3 =		(u8*)0x01000100;
-u8* const WAVEDATA4 =		(u8*)0x01000180;
-u8* const WAVEDATA5 =		(u8*)0x01000200;
-u8* const MODDATA =			(u8*)0x01000280;
-SOUNDREG* const SND_REGS =	(SOUNDREG*)0x01000400;
+volatile u8* const WAVEDATA1 =		(u8*)0x01000000;
+volatile u8* const WAVEDATA2 =		(u8*)0x01000080;
+volatile u8* const WAVEDATA3 =		(u8*)0x01000100;
+volatile u8* const WAVEDATA4 =		(u8*)0x01000180;
+volatile u8* const WAVEDATA5 =		(u8*)0x01000200;
+volatile u8* const MODDATA =		(u8*)0x01000280;
+volatile SOUNDREG* const SND_REGS =	(SOUNDREG*)0x01000400;

--- a/source/audio.h
+++ b/source/audio.h
@@ -31,13 +31,13 @@ typedef struct SOUNDREG
 	u8 spacer8[35];
 } SOUNDREG;
 
-extern u8* const WAVEDATA1;
-extern u8* const WAVEDATA2;
-extern u8* const WAVEDATA3;
-extern u8* const WAVEDATA4;
-extern u8* const WAVEDATA5;
-extern u8* const MODDATA;
-extern SOUNDREG* const SND_REGS;
+extern volatile u8* const WAVEDATA1;
+extern volatile u8* const WAVEDATA2;
+extern volatile u8* const WAVEDATA3;
+extern volatile u8* const WAVEDATA4;
+extern volatile u8* const WAVEDATA5;
+extern volatile u8* const MODDATA;
+extern volatile SOUNDREG* const SND_REGS;
 #define SSTOP				*(u8*)0x01000580
 
 /***** Sound Register Mnemonics *****/

--- a/source/interrupts.h
+++ b/source/interrupts.h
@@ -5,11 +5,11 @@
 #include "types.h"
 
 
-extern u32 keyVector;
-extern u32 timVector;
-extern u32 croVector;
-extern u32 comVector;
-extern u32 vpuVector;
+extern volatile u32 keyVector;
+extern volatile u32 timVector;
+extern volatile u32 croVector;
+extern volatile u32 comVector;
+extern volatile u32 vpuVector;
 
 
 #endif

--- a/source/mem.c
+++ b/source/mem.c
@@ -2,9 +2,9 @@
 #include "mem.h"
 
 
-u8* const	EXPANSION =	(u8*)0x04000000;	// Expansion bus area
-u8* const	WORKRAM =	(u8*)0x05000000;	// Scratchpad RAM; USE WITH CAUTION! (In fact, just leave it alone!)
-u16* const	SAVERAM =	(u16*)0x06000000;	// Cartridge's Battery-backed SRAM
+volatile u8* const	EXPANSION =	(u8*)0x04000000;	// Expansion bus area
+volatile u8* const	WORKRAM =	(u8*)0x05000000;	// Scratchpad RAM; USE WITH CAUTION! (In fact, just leave it alone!)
+volatile u16* const	SAVERAM =	(u16*)0x06000000;	// Cartridge's Battery-backed SRAM
 
 
 /***** Ancillary Functions *****/

--- a/source/mem.h
+++ b/source/mem.h
@@ -5,9 +5,9 @@
 #include "types.h"
 
 
-extern u8* const	EXPANSION;
-extern u8* const	WORKRAM;
-extern u16* const	SAVERAM;
+extern volatile u8* const	EXPANSION;
+extern volatile u8* const	WORKRAM;
+extern volatile u16* const	SAVERAM;
 
 
 /***** Ancillary Functions *****/

--- a/source/video.c
+++ b/source/video.c
@@ -4,14 +4,14 @@
 
 
 /***** Display RAM *****/
-u32* const	L_FRAME0 =	(u32*)0x00000000;	// Left Frame Buffer 0
-u32* const	L_FRAME1 =	(u32*)0x00008000;	// Left Frame Buffer 1
-u32* const	R_FRAME0 =	(u32*)0x00010000;	// Right Frame Buffer 0
-u32* const	R_FRAME1 =	(u32*)0x00018000;	// Right Frame Buffer 1
-u16* const	BGMM =		(u16*)BGMMBase;		// Pointer to BGMM
-u16* const	WAM =		(u16*)WAMBase;		// Pointer to WAM
-u16* const	CLMN_TBL =	(u16*)0x0003DC00;	// Base address of Column Tables
-u16* const	OAM =		(u16*)OAMBase;		// Pointer to OAM
+volatile u32* const	L_FRAME0 =	(u32*)0x00000000;	// Left Frame Buffer 0
+volatile u32* const	L_FRAME1 =	(u32*)0x00008000;	// Left Frame Buffer 1
+volatile u32* const	R_FRAME0 =	(u32*)0x00010000;	// Right Frame Buffer 0
+volatile u32* const	R_FRAME1 =	(u32*)0x00018000;	// Right Frame Buffer 1
+volatile u16* const	BGMM =		(u16*)BGMMBase;		// Pointer to BGMM
+volatile u16* const	WAM =		(u16*)WAMBase;		// Pointer to WAM
+volatile u16* const	CLMN_TBL =	(u16*)0x0003DC00;	// Base address of Column Tables
+volatile u16* const	OAM =		(u16*)OAMBase;		// Pointer to OAM
 
 
 /* Macro to set the brightness registers */

--- a/source/video.h
+++ b/source/video.h
@@ -7,24 +7,24 @@
 
 
 /***** Display RAM *****/
-extern u32* const	L_FRAME0;
+extern volatile u32* const	L_FRAME0;
 #define		CharSeg0		 0x00006000					// Characters 0-511
-extern u32* const	L_FRAME1;
+extern volatile u32* const	L_FRAME1;
 #define		CharSeg1		 0x0000E000					// Characters 512-1023
-extern u32* const	R_FRAME0;
+extern volatile u32* const	R_FRAME0;
 #define		CharSeg2		 0x00016000					// Characters 1024-1535
-extern u32* const	R_FRAME1;
+extern volatile u32* const	R_FRAME1;
 #define		CharSeg3		 0x0001E000					// Characters 1536-2047
 #define		BGMMBase		 0x00020000					// Base address of BGMap Memory
-extern u16* const	BGMM;
+extern volatile u16* const	BGMM;
 #define		BGMap(b)		 (BGMMBase + (b * 0x2000))	// Address of BGMap b (0 <= b <= 13)
 
 #define		WAMBase			 0x0003D800					// Base address of World Attribute Memory
-extern u16* const	WAM;
+extern volatile u16* const	WAM;
 #define		World(w)		 (WAMBase + (w * 0x0020))	// Address of World w (0 <= w <= 31)
-extern u16* const	CLMN_TBL;
+extern volatile u16* const	CLMN_TBL;
 #define		OAMBase			 0x0003E000					// Base address of Object Attribute Memory
-extern u16* const	OAM;
+extern volatile u16* const	OAM;
 #define		Object(o)		 (OAMBase + (o * 0x0008))	// Address of Obj o (0 <= o <= 1023)
 
 /* Macro to set the brightness registers */

--- a/source/world.c
+++ b/source/world.c
@@ -3,7 +3,7 @@
 #include "world.h"
 
 
-WORLD* const WA = (WORLD*)0x0003D800;
+volatile WORLD* const WA = (WORLD*)0x0003D800;
 
 
 /***** World Functions *****/

--- a/source/world.h
+++ b/source/world.h
@@ -22,7 +22,7 @@ typedef struct WORLD
 	u16 spacer[5];
 } WORLD;
 
-extern WORLD* const WA;
+extern volatile WORLD* const WA;
 
 /* "vbSetWorld" header flags */
 /* (OR these together to build a World Header) */


### PR DESCRIPTION
I should have done this in the previous PR, but I noticed a large number of other MMIO variables were not marked volatile. Some of these, like the VSU registers, _probably_ don't need to be volatile as nothing else will likely change them, but in my mind it's safest to mark them all volatile just in case.