### PR TITLE
Replace the old RNG with one that... does something

### DIFF
--- a/source/random.c
+++ b/source/random.c
@@ -1,34 +1,8 @@
+#include "types.h"
 #include "random.h"
 
-
-// When run at startup gets a random number based on the changing CTA
-long randseed()
-{
-	long
-		random = 1;
-	int
-		rand,
-		prevnum = 0,
-		count = 1;
-
-	while (count < 30000)	//repeat through many times to make more random and to allow the CTA value to change multiple times
-	{
-		rand = VIP_REGS[CTA];						//CTA = (*(BYTE*)(0x0005F830));
-		if (random == 0) random = 1;				//prevent % by zero
-			
-		random += ((rand*count) + (count%random));	//just randomly doing stuff to the number
-
-		if (rand == prevnum)						//if the CTA value doesnt change then count up
-			count++;
-		else
-			count = 0;								//if the number does change then restart the counter
-		prevnum = rand;								//keep track of the last number
-	}
-	return random;									//returns the random seed
-}
-
 // Returns a random number in the requested range from the random seed
-int randnum(long seed, int randnums)
-{
-	return (seed%randnums);
+u32 rng(u32 *seed, u32 max) {
+    *seed = *seed * 0x41C64E6D + 12345;
+    return (*seed >> 16 & 0x7FFF) * (max + 1) / 0x8000;
 }

--- a/source/random.h
+++ b/source/random.h
@@ -1,9 +1,8 @@
 #ifndef _LIBGCCVB_RANDOM_H
 #define _LIBGCCVB_RANDOM_H
 
+#include "types.h"
 
-long randseed();
-int randnum(long seed, int randnums);
-
+u32 rng(u32 *seed, u32 max);
 
 #endif


### PR DESCRIPTION
The old `long randseed()` used repeated CTA reads for randomness, so it was very slow (at least 75ms! that's like four frames!!) and deterministic on most emulators (assuming you called it at startup, before user input could affect anything).

The old `int randnum(long randseed, int randnums)` didn't modify `randseed` (so call it 5 times and you get the same number every time) and barely even hashed the seed anyway (just doing a mod).

Replace both of those with a `u32 rng(u32 *seed, u32 max)`. The caller provides their own seed (from controller input or SRAM or something), and gets back a pseudorandom number. Simple as.